### PR TITLE
feat: [#2] MySQL 도커 연동 및 DB 연결 설정 완료

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Build Stage
+# open JDK 17 기반 이미지
+FROM openjdk:17-jdk-slim
+
+# 작업 디렉토리
+WORKDIR /app
+
+# JAR 파일, 설정 파일 컨테이너로 복사
+COPY cloop-0.0.1-SNAPSHOT.jar /app/app.jar
+COPY application.yml /app/config/application.yml
+COPY .env /app/
+
+EXPOSE 8080
+
+# 컨테이너 실행 시 명령어
+ENTRYPOINT [
+  "java",
+  "-jar",
+  "-Dspring.config.location=/app/config/application.yml",
+  "/app/app.jar"
+]

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'mysql:mysql-connector-java:8.0.33'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: cloop-container
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: cloop
+    ports:
+      - "3306:3306"
+    volumes:
+      - cloop-data:/var/lib/mysql
+
+volumes:
+  cloop-data:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3306/cloop?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&createDatabaseIfNotExist=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: password
+
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQLDialect
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    org.springframework.jdbc.datasource.DriverManagerDataSource: DEBUG
+    org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator: DEBUG


### PR DESCRIPTION
### ✨ Feature
> DB 연동 설정 및 서버 실행 환경 구축

### 📌 구현 내용

- [x] Docker 기반 MySQL 컨테이너 실행 및 포트 3306 확인
- [x] cloop DB 생성 완료 (Workbench 연동 확인 완료)
- [x] application.yml 내 DB 접속 정보 설정
- [x]  Spring Boot 앱 정상 실행 (8080 포트, DB 연결 확인 로그 포함)
- [x] Hibernate ORM 설정 및 JPA 동작 확인 (Entity/Repository는 연동 확인 X)