### PR TITLE
feat: looks - 사진 등록 기능 구현

### DIFF
--- a/src/main/java/com/cloop/cloop/auth/domain/User.java
+++ b/src/main/java/com/cloop/cloop/auth/domain/User.java
@@ -1,10 +1,13 @@
 package com.cloop.cloop.auth.domain;
 
+import com.cloop.cloop.looks.domain.Look;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Entity
 @Table(name = "`user`")
@@ -26,4 +29,9 @@ public class User {
 
     @Column(nullable = false)
     private String gender;
+
+    // 착장 테이블과 1:N 관계
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Look> looks;
+
 }

--- a/src/main/java/com/cloop/cloop/global/file/FileHandler.java
+++ b/src/main/java/com/cloop/cloop/global/file/FileHandler.java
@@ -1,4 +1,4 @@
-package com.cloop.cloop.looks.controller;
+package com.cloop.cloop.global.file;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/cloop/cloop/global/file/Image.java
+++ b/src/main/java/com/cloop/cloop/global/file/Image.java
@@ -1,0 +1,40 @@
+package com.cloop.cloop.global.file;
+
+import com.cloop.cloop.looks.domain.Look;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Base64;
+
+@Entity
+@Table(name= "image")
+@Inheritance(strategy = InheritanceType.JOINED)     // cloth_image, look_image 자식 테이블 지정
+@Getter
+@Setter
+@NoArgsConstructor
+public abstract class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long imageId;
+
+    //  저장한 이미지 이름
+    private String imageName;
+
+    // 이미지 정보
+    @Lob
+    @Column(columnDefinition = "MEDIUMBLOB")
+    private byte[] imageData;
+
+    // base64 문자열 추가
+    public String getBase64Image() {
+        return Base64.getEncoder().encodeToString(this.imageData);
+    }
+
+    public Image(String imageName, byte[] imageData) {
+        this.imageName = imageName;
+        this.imageData = imageData;
+    }
+}

--- a/src/main/java/com/cloop/cloop/global/file/ImageRepository.java
+++ b/src/main/java/com/cloop/cloop/global/file/ImageRepository.java
@@ -1,0 +1,6 @@
+package com.cloop.cloop.global.file;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/cloop/cloop/global/file/ImageService.java
+++ b/src/main/java/com/cloop/cloop/global/file/ImageService.java
@@ -1,0 +1,67 @@
+package com.cloop.cloop.global.file;
+
+import com.cloop.cloop.looks.domain.Look;
+import com.cloop.cloop.looks.domain.LookImage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public void saveImage(List<MultipartFile> imageList, Look look) {
+
+        // 업로드한 파일이 없을 경우
+        if (imageList == null) {
+            return;
+        }
+
+        // 업로드한 사진의 타입 검사
+        for (MultipartFile image : imageList) {
+            if (!isImageFile(image)) throw new IllegalArgumentException(".jpg, .png, .svg 등 이미지 파일만 업로드 가능합니다.");
+        }
+
+        try {
+            // 각 사진들을 db에 저장
+            for (MultipartFile image : imageList) {
+
+                // 파일이 비어 있을 경우
+                if(Objects.requireNonNull(image.getOriginalFilename()).isEmpty()) continue;
+
+                // 이미지 이름 중복 방지 -> UUID 추가
+                String imageName = addUUID(image.getOriginalFilename());
+
+                // lookImage 엔티티 생성, Look과 연관 관계 설정
+                LookImage lookImages = new LookImage(imageName, image.getBytes());
+                lookImages.setLook(look);
+
+                // 생성한 lookImage 엔티티 저장
+                imageRepository.save(lookImages);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // 파일이 이미지 형식인지 검사하는 메서드
+    private static boolean isImageFile(MultipartFile image) {
+        String contentType = image.getContentType();
+        return contentType != null && contentType.startsWith("image/");
+    }
+
+    // 이미지 이름 앞에 UUID 추가 (이미지 이름 중복을 피하기 위함)
+    private static String addUUID(String originalFilename) {
+        return UUID.randomUUID().toString().replace("-", "") + "_" + originalFilename;
+    }
+
+}

--- a/src/main/java/com/cloop/cloop/looks/controller/FileHandler.java
+++ b/src/main/java/com/cloop/cloop/looks/controller/FileHandler.java
@@ -1,0 +1,38 @@
+package com.cloop.cloop.looks.controller;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class FileHandler {
+
+    private static final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/look/";
+
+    public String saveFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("빈 파일입니다.");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String photoType = originalFilename.substring(originalFilename.lastIndexOf("."));
+        String newFilename = UUID.randomUUID() + photoType;
+
+        File directory = new File(UPLOAD_DIR);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        File dest = new File(UPLOAD_DIR + newFilename);
+        try {
+            file.transferTo(dest);
+        } catch (IOException e) {
+            throw new RuntimeException("파일 저장 중 오류가 발생했습니다.", e);
+        }
+
+        return UPLOAD_DIR + newFilename;
+    }
+}

--- a/src/main/java/com/cloop/cloop/looks/controller/LookController.java
+++ b/src/main/java/com/cloop/cloop/looks/controller/LookController.java
@@ -1,0 +1,39 @@
+package com.cloop.cloop.looks.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/looks")
+@RequiredArgsConstructor
+public class LookController {
+
+    private final FileHandler fileHandler;
+
+    @PostMapping("/image")
+    public ResponseEntity<?> uploadImage(@RequestParam("image") MultipartFile image) {
+        if (image.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "사진을 등록해 주세요."));
+        }
+
+        try {
+            String imageUrl = fileHandler.saveFile(image);
+            return ResponseEntity.ok(Map.of("imageUrl", imageUrl));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", "이미지 업로드 실패: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/test-upload")
+    public ResponseEntity<?> upload(@RequestPart("image") MultipartFile image) {
+        return ResponseEntity.ok(Map.of(
+                "filename", image,
+                "size", image.getSize()
+        ));
+    }
+
+}

--- a/src/main/java/com/cloop/cloop/looks/controller/LookController.java
+++ b/src/main/java/com/cloop/cloop/looks/controller/LookController.java
@@ -1,5 +1,6 @@
 package com.cloop.cloop.looks.controller;
 
+import com.cloop.cloop.global.file.FileHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,14 +27,6 @@ public class LookController {
         } catch (Exception e) {
             return ResponseEntity.status(500).body(Map.of("error", "이미지 업로드 실패: " + e.getMessage()));
         }
-    }
-
-    @PostMapping("/test-upload")
-    public ResponseEntity<?> upload(@RequestPart("image") MultipartFile image) {
-        return ResponseEntity.ok(Map.of(
-                "filename", image,
-                "size", image.getSize()
-        ));
     }
 
 }

--- a/src/main/java/com/cloop/cloop/looks/domain/Look.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/Look.java
@@ -1,0 +1,35 @@
+package com.cloop.cloop.looks.domain;
+
+import com.cloop.cloop.auth.domain.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Entity
+@Table(name="look")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Look {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long lookId;
+
+    @Column(nullable = false)
+    private String photo;
+
+    @Column(nullable = false)
+    private Date createdAt;
+
+    // User와 FK 관계 설정
+    @ManyToOne
+    @JoinColumn(name="userId", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/cloop/cloop/looks/domain/Look.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/Look.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Entity
 @Table(name="look")
@@ -21,8 +23,12 @@ public class Look {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long lookId;
 
-    @Column(nullable = false)
-    private String photo;
+//    @Column(nullable = false)
+//    private String photo;
+
+    // 착장 당 여러 개의 사진을 등록할 수 있음 -> 1 : N
+    @OneToMany(mappedBy = "look", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LookImage> lookImageList = new ArrayList<>();
 
     @Column(nullable = false)
     private Date createdAt;

--- a/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.Base64;
-
 @Entity
 @Table(name= "lookImage")       // image 엔티티를 상속 받아 자식 테이블로 생성
 @Getter

--- a/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
@@ -1,5 +1,6 @@
 package com.cloop.cloop.looks.domain;
 
+import com.cloop.cloop.global.file.Image;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,32 +9,16 @@ import lombok.Setter;
 import java.util.Base64;
 
 @Entity
-@Table(name= "lookImage")
+@Table(name= "lookImage")       // image 엔티티를 상속 받아 자식 테이블로 생성
 @Getter
 @Setter
 @NoArgsConstructor
-public class LookImage {
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long imageId;
+public class LookImage extends Image {
 
     // N:1 관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name= "lookId")
     private Look look;
-
-    //  저장한 이미지 이름
-    private String imageName;
-
-    // 이미지 정보
-    @Lob
-    @Column(columnDefinition = "MEDIUMBLOB")
-    private byte[] imageData;
-
-    // base64 문자열 추가
-    public String getBase64Image() {
-        return Base64.getEncoder().encodeToString(this.imageData);
-    }
 
     // 연관 관계 편의 메서드
     public void setLook (Look look) {
@@ -42,8 +27,7 @@ public class LookImage {
     }
 
     public LookImage(String imageName, byte[] imageData) {
-        this.imageName = imageName;
-        this.imageData = imageData;
+        super(imageName, imageData);
     }
 
 }

--- a/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
@@ -1,0 +1,49 @@
+package com.cloop.cloop.looks.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Base64;
+
+@Entity
+@Table(name= "lookImage")
+@Getter
+@Setter
+@NoArgsConstructor
+public class LookImage {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long imageId;
+
+    // N:1 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name= "lookId")
+    private Look look;
+
+    //  저장한 이미지 이름
+    private String imageName;
+
+    // 이미지 정보
+    @Lob
+    @Column(columnDefinition = "MEDIUMBLOB")
+    private byte[] imageData;
+
+    // base64 문자열 추가
+    public String getBase64Image() {
+        return Base64.getEncoder().encodeToString(this.imageData);
+    }
+
+    // 연관 관계 편의 메서드
+    public void setLook (Look look) {
+        this.look = look;
+        look.getLookImageList().add(this);
+    }
+
+    public LookImage(String imageName, byte[] imageData) {
+        this.imageName = imageName;
+        this.imageData = imageData;
+    }
+
+}

--- a/src/main/java/com/cloop/cloop/looks/dto/LookDto.java
+++ b/src/main/java/com/cloop/cloop/looks/dto/LookDto.java
@@ -1,0 +1,17 @@
+package com.cloop.cloop.looks.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LookDto {
+
+
+    private List<MultipartFile> imageList;
+}

--- a/src/main/java/com/cloop/cloop/looks/repository/LookImageRepository.java
+++ b/src/main/java/com/cloop/cloop/looks/repository/LookImageRepository.java
@@ -1,0 +1,7 @@
+package com.cloop.cloop.looks.repository;
+
+import com.cloop.cloop.looks.domain.LookImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LookImageRepository extends JpaRepository<LookImage, Long> {
+}

--- a/src/main/java/com/cloop/cloop/looks/repository/LookRepository.java
+++ b/src/main/java/com/cloop/cloop/looks/repository/LookRepository.java
@@ -1,0 +1,9 @@
+package com.cloop.cloop.looks.repository;
+
+import com.cloop.cloop.looks.domain.Look;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LookRepository extends JpaRepository<Look, Long> {
+
+
+}

--- a/src/main/java/com/cloop/cloop/looks/service/LookImageService.java
+++ b/src/main/java/com/cloop/cloop/looks/service/LookImageService.java
@@ -1,0 +1,67 @@
+package com.cloop.cloop.looks.service;
+
+import com.cloop.cloop.looks.domain.Look;
+import com.cloop.cloop.looks.domain.LookImage;
+import com.cloop.cloop.looks.repository.LookImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class LookImageService {
+
+    private final LookImageRepository lookImageRepository;
+
+    @Transactional
+    public void saveImage(List<MultipartFile> imageList, Look look) {
+
+        // 업로드한 파일이 없을 경우
+        if (imageList == null) {
+            return;
+        }
+
+        // 업로드한 사진의 타입 검사
+        for (MultipartFile image : imageList) {
+            if (!isImageFile(image)) throw new IllegalArgumentException(".jpg, .png, .svg 등 이미지 파일만 업로드 가능합니다.");
+        }
+
+        try {
+            // 각 사진들을 db에 저장
+            for (MultipartFile image : imageList) {
+
+                // 파일이 비어 있을 경우
+                if(Objects.requireNonNull(image.getOriginalFilename()).isEmpty()) continue;
+
+                // 이미지 이름 중복 방지 -> UUID 추가
+                String imageName = addUUID(image.getOriginalFilename());
+
+                // lookImage 엔티티 생성, Look과 연관 관계 설정
+                LookImage lookImages = new LookImage(imageName, image.getBytes());
+                lookImages.setLook(look);
+
+                // 생성한 lookImage 엔티티 저장
+                lookImageRepository.save(lookImages);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // 파일이 이미지 형식인지 검사하는 메서드
+    private static boolean isImageFile(MultipartFile image) {
+        String contentType = image.getContentType();
+        return contentType != null && contentType.startsWith("image/");
+    }
+
+    // 이미지 이름 앞에 UUID 추가 (이미지 이름 중복을 피하기 위함)
+    private static String addUUID(String originalFilename) {
+        return UUID.randomUUID().toString().replace("-", "") + "_" + originalFilename;
+    }
+}

--- a/src/main/java/com/cloop/cloop/looks/service/LookService.java
+++ b/src/main/java/com/cloop/cloop/looks/service/LookService.java
@@ -1,0 +1,9 @@
+package com.cloop.cloop.looks.service;
+
+import com.cloop.cloop.looks.repository.LookImageRepository;
+import com.cloop.cloop.looks.repository.LookRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public class LookService {
+
+}

--- a/src/main/java/com/cloop/cloop/looks/service/LookService.java
+++ b/src/main/java/com/cloop/cloop/looks/service/LookService.java
@@ -1,9 +1,21 @@
 package com.cloop.cloop.looks.service;
 
-import com.cloop.cloop.looks.repository.LookImageRepository;
-import com.cloop.cloop.looks.repository.LookRepository;
-import org.springframework.transaction.annotation.Transactional;
+import com.cloop.cloop.global.file.ImageService;
+import com.cloop.cloop.looks.domain.Look;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class LookService {
+
+    private final ImageService imageService;
+
+    public void uploadLookImage(List<MultipartFile> imageList, Look look){
+        imageService.saveImage(imageList, look);
+    }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8081
+  port: 8080
 
 spring:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,13 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
 
+  servlet:
+    # 사진 업로드 용량 제한
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 
   jpa:
     hibernate:


### PR DESCRIPTION
#7 

## ✨ Description
> 착장 사진 등록 기능 구현

## 📌 구현 내용

- [x] 착장 DB 설계
- [x] 이미지 등록 시 url 반환 로직 구현
- [ ] 착장 등록
- [ ] 날짜별 착용 통계 조회 로직

### 참고 사항
이미지 등록 후 URL 반환 로직을 Look에서 사용하던 방식을 공통 패키지(global.file)로 분리하였습니다. 
추후 Clothes - 이미지 등록 구현 시, 공통 패키지의 Image를 상속받아 사용하면 됩니다.
