### PR TITLE
feat: 날짜별 착장 조회 구현

### DIFF
--- a/src/main/java/com/cloop/cloop/global/file/Image.java
+++ b/src/main/java/com/cloop/cloop/global/file/Image.java
@@ -10,7 +10,8 @@ import java.util.Base64;
 
 @Entity
 @Table(name= "image")
-@Inheritance(strategy = InheritanceType.JOINED)     // cloth_image, look_image 자식 테이블 지정
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "image_type", discriminatorType = DiscriminatorType.STRING)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -23,18 +24,32 @@ public abstract class Image {
     //  저장한 이미지 이름
     private String imageName;
 
+    // 이미지 URL (URL로 저장된 경우)
+    @Column(nullable = true)
+    private String imageUrl;
+
     // 이미지 정보
     @Lob
     @Column(columnDefinition = "MEDIUMBLOB")
     private byte[] imageData;
 
-    // base64 문자열 추가
+    // base64 문자열로 이미지 변환
     public String getBase64Image() {
-        return Base64.getEncoder().encodeToString(this.imageData);
+        return (imageData != null) ? Base64.getEncoder().encodeToString(this.imageData) : null;
+    }
+
+    // 이미지 URL 또는 Base64 이미지 반환
+    public String getDisplayImage() {
+        return (imageUrl != null) ? imageUrl : getBase64Image();
     }
 
     public Image(String imageName, byte[] imageData) {
         this.imageName = imageName;
         this.imageData = imageData;
+    }
+
+    public Image(String imageName, String imageUrl) {
+        this.imageName = imageName;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/cloop/cloop/looks/controller/LookController.java
+++ b/src/main/java/com/cloop/cloop/looks/controller/LookController.java
@@ -5,6 +5,7 @@ import com.cloop.cloop.auth.domain.User;
 import com.cloop.cloop.auth.repository.UserRepository;
 import com.cloop.cloop.global.file.FileHandler;
 import com.cloop.cloop.looks.domain.Look;
+import com.cloop.cloop.looks.dto.LookCalendarResponseDto;
 import com.cloop.cloop.looks.dto.LookRequestDto;
 import com.cloop.cloop.looks.dto.LookResponseDto;
 import com.cloop.cloop.looks.service.LookService;
@@ -14,6 +15,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -23,8 +27,8 @@ public class LookController {
 
     private final FileHandler fileHandler;
     private final LookService lookService;
-    private final JwtUtil jwtUtil;
 
+    // 착장 사진 등록
     @PostMapping("/image")
     public ResponseEntity<?> uploadImage(@RequestParam("image") MultipartFile image) {
         if (image.isEmpty()) {
@@ -39,6 +43,7 @@ public class LookController {
         }
     }
 
+    // 착장 등록하기
     @PostMapping
     public ResponseEntity<?> createLook(
             @RequestHeader("Authorization") String token,@RequestBody LookRequestDto lookRequestDto) {
@@ -54,6 +59,30 @@ public class LookController {
             LookResponseDto response = lookService.createLook(lookRequestDto, accessToken);
             return ResponseEntity.status(201).body(response);
         } catch (IllegalArgumentException e ){
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("error", "서버 오류 : " + e.getMessage()));
+        }
+
+    }
+
+    // 날짜별 착용 조회
+    @GetMapping
+    public ResponseEntity<?> getLooksByDate(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("date") String date) {
+
+        // Authorization 헤더에서 "Bearer " 제거
+        String accessToken = token.replace("Bearer ", ""); // "Bearer " 제거
+
+        try{
+            List<LookCalendarResponseDto> looks = lookService.getLooksByDate(date, accessToken);
+
+            if (looks == null || looks.isEmpty()) {
+                return ResponseEntity.status(404).body(Map.of("error", "해당 날짜에 등록된 착장이 없습니다."));
+            }
+            return ResponseEntity.status(200).body(looks);
+        } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(500).body(Map.of("error", "서버 오류 : " + e.getMessage()));

--- a/src/main/java/com/cloop/cloop/looks/domain/Look.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/Look.java
@@ -42,8 +42,10 @@ public class Look {
 
     // LookImage 추가 (연관관계 메서드)
     public void addLookImage(LookImage lookImage) {
+        if (lookImageList == null) {
+            lookImageList = new ArrayList<>();      // null 방지
+        }
         lookImage.setLook(this);
         this.lookImageList.add(lookImage);
     }
-
 }

--- a/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
+++ b/src/main/java/com/cloop/cloop/looks/domain/LookImage.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name= "lookImage")       // image 엔티티를 상속 받아 자식 테이블로 생성
+@DiscriminatorValue("LOOK_IMAGE")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -15,7 +15,7 @@ public class LookImage extends Image {
 
     // N:1 관계
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name= "lookId")
+    @JoinColumn(name= "lookId", nullable = false)
     private Look look;
 
     // 연관 관계 편의 메서드
@@ -26,8 +26,19 @@ public class LookImage extends Image {
         }
     }
 
+    // 이미지 URL 생성자
+    public LookImage(String imageName, String imageUrl) {
+        super(imageName, imageUrl);
+    }
+
+    // Base64 이미지 생성자
     public LookImage(String imageName, byte[] imageData) {
         super(imageName, imageData);
+    }
+
+    // 이미지 URL 또는 Base64 이미지 반환
+    public String getDisplayImage() {
+        return (getImageUrl() != null) ? getImageUrl() : getBase64Image();
     }
 
 }

--- a/src/main/java/com/cloop/cloop/looks/dto/LookCalendarResponseDto.java
+++ b/src/main/java/com/cloop/cloop/looks/dto/LookCalendarResponseDto.java
@@ -1,0 +1,16 @@
+package com.cloop.cloop.looks.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class LookCalendarResponseDto {
+
+    private Long lookId;
+    private LocalDate createdAt;
+    private String imageUrl;
+
+}

--- a/src/main/java/com/cloop/cloop/looks/repository/LookRepository.java
+++ b/src/main/java/com/cloop/cloop/looks/repository/LookRepository.java
@@ -2,8 +2,15 @@ package com.cloop.cloop.looks.repository;
 
 import com.cloop.cloop.looks.domain.Look;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface LookRepository extends JpaRepository<Look, Long> {
 
-
+    // 날짜별 Look 조회
+    @Query("SELECT l FROM Look l WHERE l.createdAt = :date")
+    List<Look> findAllByCreatedAt(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/cloop/cloop/looks/service/LookService.java
+++ b/src/main/java/com/cloop/cloop/looks/service/LookService.java
@@ -8,6 +8,7 @@ import com.cloop.cloop.clothes.repository.ClothRepository;
 import com.cloop.cloop.global.file.ImageService;
 import com.cloop.cloop.looks.domain.Look;
 import com.cloop.cloop.looks.domain.LookCloth;
+import com.cloop.cloop.looks.dto.LookCalendarResponseDto;
 import com.cloop.cloop.looks.dto.LookRequestDto;
 import com.cloop.cloop.looks.dto.LookResponseDto;
 import com.cloop.cloop.looks.repository.LookRepository;
@@ -17,8 +18,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -79,6 +82,31 @@ public class LookService {
                 .message("착장이 성공적으로 저장되었습니다.")
                 .build();
 
+    }
+
+    // 날짜별 look 조회
+    @Transactional(readOnly = true)
+    public List<LookCalendarResponseDto> getLooksByDate(String date, String token){
+
+        Long userId = jwtUtil.extractUserId(token); // JWT에서 userId 추출
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 userId를 찾을 수 없습니다."));
+
+        LocalDate targetDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        List<Look> looks = lookRepository.findAllByCreatedAt(targetDate);
+
+        return looks.stream()
+                .map(look -> LookCalendarResponseDto.builder()
+                        .lookId(look.getLookId())
+                        .createdAt(look.getCreatedAt())
+                        .imageUrl(getFirstImageUrl(look))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // Look의 첫 번째 이미지 URL 반환 (없을 경우 null)
+    private String getFirstImageUrl(Look look) {
+        return look.getLookImageList().isEmpty() ? null : look.getLookImageList().get(0).getBase64Image();
     }
 
     public void uploadLookImage(List<MultipartFile> imageList, Look look){

--- a/src/main/java/com/cloop/cloop/looks/service/LookService.java
+++ b/src/main/java/com/cloop/cloop/looks/service/LookService.java
@@ -8,6 +8,7 @@ import com.cloop.cloop.clothes.repository.ClothRepository;
 import com.cloop.cloop.global.file.ImageService;
 import com.cloop.cloop.looks.domain.Look;
 import com.cloop.cloop.looks.domain.LookCloth;
+import com.cloop.cloop.looks.domain.LookImage;
 import com.cloop.cloop.looks.dto.LookCalendarResponseDto;
 import com.cloop.cloop.looks.dto.LookRequestDto;
 import com.cloop.cloop.looks.dto.LookResponseDto;
@@ -73,6 +74,13 @@ public class LookService {
         // Look과 LookCloth 연결
         lookClothList.forEach(lookCloth -> lookCloth.setLook(look));
 
+        // LookImage 생성 (URL 또는 Base64 이미지)
+        if (lookRequestDto.getImageUrl() != null && !lookRequestDto.getImageUrl().isEmpty()) {
+            // LookImage 생성 (URL 이미지로 저장)
+            LookImage lookImage = new LookImage("Look Image", lookRequestDto.getImageUrl());
+            look.addLookImage(lookImage); // Look에 이미지 추가
+        }
+
         // Look 저장
         Look savedLook = lookRepository.save(look);
 
@@ -106,7 +114,10 @@ public class LookService {
 
     // Look의 첫 번째 이미지 URL 반환 (없을 경우 null)
     private String getFirstImageUrl(Look look) {
-        return look.getLookImageList().isEmpty() ? null : look.getLookImageList().get(0).getBase64Image();
+        if (look.getLookImageList() != null && !look.getLookImageList().isEmpty()) {
+            return look.getLookImageList().get(0).getDisplayImage();
+        }
+        return null;
     }
 
     public void uploadLookImage(List<MultipartFile> imageList, Look look){


### PR DESCRIPTION
#7 

## ✨ Description
> 날짜별 착장 조회 구현
> Look 생성 시 이미지가 저장되지 않고 출력되지 않는 문제를 해결

## 📌 구현 내용
- [x] 날짜별 착장 조회 구현
- [x] 착장 등록 시 이미지 출력 오류 해결
 
### 🔍 해결한 문제
- Look 생성 시 이미지가 저장되지 않거나, LookImage가 Look과 연결되지 않는 문제
- 이미지 출력 시 NullPointerException 발생 (LookImage 리스트가 null)
- Look 조회 시 이미지가 정상적으로 출력되지 않음

### 🔧 주요 수정 사항
- Look 엔티티의 `lookImageList`를 자동으로 빈 리스트로 초기화하여 NullPointerException 방지
- LookImage 추가 시 Look과의 관계를 명확히 설정 (`addLookImage` 메서드 개선)
- Look 생성 시 LookImage가 URL로 저장될 수 있도록 로직 수정
- LookImage를 Look에 정상적으로 추가하고 Look 저장 시 함께 저장되도록 개선
- LookImage의 URL이 정상적으로 출력되도록 로직 수정
